### PR TITLE
BACKLOG-22965: Revert skips needed for release

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -63,5 +63,5 @@ jobs:
           fi
           NEXT_REVISION=$(expr $REVISION + 1)
           NEXT_DEVELOPMENT_VERSION="$(echo $FINAL_RELEASE_VERSION | cut -d'-' -f1)-jahia${NEXT_REVISION}"-SNAPSHOT # e.g. 6.0.0.Final-jahia3-SNAPSHOT
-          mvn -B -s .github/maven.settings.xml -Dtag=$TAG_VERSION -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]" release:prepare
-          mvn -B -s .github/maven.settings.xml release:perform
+          mvn -B -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Dtag=$TAG_VERSION -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]" -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:prepare
+          mvn -B -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:perform


### PR DESCRIPTION
This reverts commit 41cc0c34ec2fe31013738b5af414b080eba6a05d.

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22965

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->



From this error release run: https://github.com/Jahia/drools/actions/runs/9878783444/job/27283478971#step:8:7796

```
Error: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8:jar (attach-javadocs) on project drools-core: MavenReportException: Error while creating archive: 
[...]
```

Looks like we need some of the skips removed by this PR: https://github.com/Jahia/drools/pull/10
