### PR TITLE
BACKLOG-22965: Add scm provider to push changes to repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
                 <scope>import</scope>
             </dependency>
         </dependencies>
+        
     </dependencyManagement>
 
     <distributionManagement>
@@ -103,6 +104,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-api</artifactId>
+                        <version>1.11.3</version>
+                     </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.11.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22965

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Another issue with release: https://github.com/Jahia/drools/actions/runs/9879150902

Looks like `release:prepare` is not pushing anything to the remote repository and so the git clone from `release:perform` fails: https://github.com/Jahia/drools/actions/runs/9879150902/job/27284737136#step:8:10246

```
[INFO] Executing: /bin/sh -c cd '/home/runner/work/drools/drools/target' && 'git' 'clone' '--depth' '1' '--branch' '6.0.0.Final-jahia2' 'git@github.com:Jahia/drools.git' 'checkout'
[INFO] Working directory: /home/runner/work/drools/drools/target
Error:  The git-clone command failed.
```

From https://stackoverflow.com/a/63447243, adding `maven-scm-provider-gitexe` as a dependency to `maven-release-plugin`