### PR TITLE
BACKLOG-22965: Explicitly enable to push changes to repo in release:prepare

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -64,7 +64,7 @@ jobs:
           NEXT_REVISION=$(expr $REVISION + 1)
           NEXT_DEVELOPMENT_VERSION="$(echo $FINAL_RELEASE_VERSION | cut -d'-' -f1)-jahia${NEXT_REVISION}"-SNAPSHOT # e.g. 6.0.0.Final-jahia3-SNAPSHOT
           echo "TAG_VERSION=${TAG_VERSION}"
-          echo "NEXT_REVISION=${NEXT_REVISION}"
+          echo "FINAL_RELEASE_VERSION=${FINAL_RELEASE_VERSION}"
           echo "NEXT_DEVELOPMENT_VERSION=${NEXT_DEVELOPMENT_VERSION}"
-          mvn -B -X -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Dtag=$TAG_VERSION -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]" -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:prepare
-          mvn -B -X -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:perform
+          mvn -B -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Dtag=$TAG_VERSION -DreleaseVersion=$FINAL_RELEASE_VERSION -DdevelopmentVersion="$NEXT_DEVELOPMENT_VERSION" -DscmCommentPrefix="[skip ci] [maven-release-plugin]" -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:prepare
+          mvn -B -s .github/maven.settings.xml -DdryRun=false -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true -Darguments="-Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true -Dmaven.javadoc.skip=true -Dgpg.skip=true" release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -104,18 +104,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-api</artifactId>
-                        <version>2.0.1</version>
-                     </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>2.0.1</version>
-                    </dependency>
-                </dependencies>
+                <configuration>
+                    <pushChanges>true</pushChanges>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22965

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

After running with debug, it seems `pushChanges` attribute for release:prepare is set to false from [pom ancestor](https://repo1.maven.org/maven2/org/kie/kie-parent-metadata/6.0.0.Final/kie-parent-metadata-6.0.0.Final.pom) which is what's preventing the push to repo.

Need to explicitly override this in the pom configuration to enable. 

Also reverting https://github.com/Jahia/drools/pull/15 as I don't think it's needed anymore.